### PR TITLE
🐳 🐛 Fix order of operations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,12 @@ FROM debian:stable-slim AS runtime
 ARG KUBECTL_VERSION "v1.21.1"
 ARG KUBECTL_URL "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
 
+COPY --from=builder /workspace/dist/klander /usr/local/bin/klander
+ADD ${KUBECTL_URL} /usr/local/bin/kubectl
+RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/klander
+
 RUN useradd -m -s /bin/bash -d /workspace klander
 USER klander
 WORKDIR /workspace
-
-ADD ${KUBECTL_URL} /usr/local/bin/kubectl
-RUN chmod +x /usr/local/bin/kubectl
-
-COPY --from=builder /workspace/dist/klander /usr/local/bin/klander
 
 CMD ["klander"]


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: Install `kubectl` and `klander` before switching user